### PR TITLE
Remove extra carriage return in M48 V1 output

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5196,8 +5196,8 @@ inline void gcode_M42() {
             SERIAL_PROTOCOLPGM(" range: ");
             SERIAL_PROTOCOL_F(max-min, 3);
           }
+          SERIAL_EOL;
         }
-        SERIAL_EOL;
       }
 
     } // End of probe loop


### PR DESCRIPTION
When M48 is run with default verbosity (V1) there is an unnecessary carriage return in the output.  This PR removes it.  Other verbosity levels are unaffected and output is as expected (and unchanged).

M48 V1 before this change:
```
M48 Z-Probe Repeatability Test




Finished!
Mean: 2.554484 Min: 2.553 Max: 2.558 Range: 0.005
Standard Deviation: 0.002077

X:130.00 Y:138.00 Z:12.55 E:0.00 Count X:12974 Y:13939 Z:5010
```

M48 V1 output after the change:
```
M48 Z-Probe Repeatability Test
Finished!
Mean: 2.553858 Min: 2.550 Max: 2.558 Range: 0.008
Standard Deviation: 0.003758

X:130.00 Y:138.00 Z:12.55 E:0.00 Count X:12974 Y:13939 Z:5010
```